### PR TITLE
fixes

### DIFF
--- a/src/App/Http/Resources/Event.php
+++ b/src/App/Http/Resources/Event.php
@@ -41,7 +41,7 @@ class Event extends JsonResource
     protected function isLast()
     {
         return $this->parentId()
-            ? EventModel::cacheGet($this->parentId())
+            ? EventModel::find($this->parentId())
             ->recurrence_ends_at->eq($this->start_date)
             : false;
     }

--- a/src/App/Http/Resources/Event.php
+++ b/src/App/Http/Resources/Event.php
@@ -41,8 +41,7 @@ class Event extends JsonResource
     protected function isLast()
     {
         return $this->parentId()
-            ? EventModel::find($this->parentId())
-            ->recurrence_ends_at->eq($this->start_date)
+            ? $this->parent->recurrence_ends_at->eq($this->start_date)
             : false;
     }
 

--- a/src/App/Http/Responses/Events.php
+++ b/src/App/Http/Responses/Events.php
@@ -33,7 +33,7 @@ class Events implements Responsable
         $nativeCalendars = $this->calendars
             ->filter(fn ($calendar) => $this->isNative($calendar));
 
-        return Event::for($nativeCalendars)->between(
+        return Event::with('parent')->for($nativeCalendars)->between(
             $this->request->get('startDate'),
             $this->request->get('endDate')
         )->get();

--- a/src/App/Services/Frequency/Delete.php
+++ b/src/App/Services/Frequency/Delete.php
@@ -39,6 +39,8 @@ class Delete
 
     private function currentAndFuture()
     {
+        (new Sequence($this->event))->break();
+
         Event::sequence($this->event->parent_id ?? $this->event->id)
             ->where('start_date', '>=', $this->event->start_date->format('Y-m-d'))
             ->delete();

--- a/src/App/Services/Frequency/Update.php
+++ b/src/App/Services/Frequency/Update.php
@@ -81,7 +81,7 @@ class Update
 
     private function shouldRegenerate(): bool
     {
-        return $this->event->isDirty(['frequence', ...$this->event->getDates()]);
+        return $this->event->isDirty(['frequency', ...$this->event->getDates()]);
     }
 
     private function isSingular(): bool

--- a/src/App/Services/Sequence.php
+++ b/src/App/Services/Sequence.php
@@ -85,10 +85,12 @@ class Sequence
 
     private function updateFrequency()
     {
-        $this->event->update([
-            'parent_id' => null,
-            'frequency' => Frequencies::Once,
-            'recurrence_ends_at' => null,
-        ]);
+        if ($this->singular) {
+            $this->event->update([
+                'parent_id' => null,
+                'frequency' => Frequencies::Once,
+                'recurrence_ends_at' => null,
+            ]);
+        }
     }
 }


### PR DESCRIPTION
* When an event in the middle of the sequence is deleted, then should break the sequence first then delete events.
* When series of events are updated in the middle of the sequence then should not change the frequency
* When a sequence of events is deleted, then the cache will be invalid // I disabled the cache for solving this temporary.